### PR TITLE
Tests for TZ fixes, and another TZ fix

### DIFF
--- a/lib/Data/ICal/DateTime.pm
+++ b/lib/Data/ICal/DateTime.pm
@@ -486,10 +486,10 @@ sub _rule_set {
 
     my @recurrence;
     my $start = $self->start || return undef;
-    my $tz    = $start->time_zone;
+    #my $tz    = $start->time_zone;
 
     $start = $start->clone;
-    $start->set_time_zone("floating");
+    #$start->set_time_zone("floating");
 
     my $set = DateTime::Set->empty_set;
     $self->property($name) || return undef;

--- a/t/01.parse_recurring.t
+++ b/t/01.parse_recurring.t
@@ -1,6 +1,6 @@
 use strict;
 
-use Test::More tests => 4;
+use Test::More tests => 18;
 use Data::ICal::DateTime;
 use DateTime;
 use DateTime::Set;
@@ -18,6 +18,14 @@ my @events = $cal->events;
 is (@events, 1, "1 total event");
 @events    = $cal->events($set);
 is (@events, 7, "7 recurring events");
+
+my $day = 20;
+for my $event (@events) {
+    is($event->start->iso8601, "2005-06-${day}T11:00:00");
+    is($event->start->time_zone_long_name, 'Europe/London');
+
+    $day++;
+}
 
 @events    = $cal->events($set,'minute');
 is (@events, 7*60, "420 split recurring events");

--- a/t/complex-dtstart.t
+++ b/t/complex-dtstart.t
@@ -1,0 +1,22 @@
+use strict;
+
+use Test::More tests => 2;
+
+use DateTime;
+use Data::ICal;
+use Data::ICal::DateTime;
+
+my $d = Data::ICal->new( filename => 't/ics/test.ics' );
+
+my $st = DateTime->new(
+    year => 2014, month  =>  1, day    =>  2,
+    hour => 12,   minute => 34, second => 56,
+    time_zone => 'America/Chicago',
+);
+
+my ($e) = $d->events;
+$e->start($st);
+
+my $dtstart = $e->property('dtstart')->[0];
+is($dtstart->value, '20140102T123456');
+is($dtstart->parameters->{TZID}, 'America/Chicago');


### PR DESCRIPTION
I would really like it if the latest code were released. It has some very handy 6 year old TZ fixes that make using recurring ICS links from Google Calendar usable without having to write all the DateTime parsing myself. 

This pull request includes one small fix to give recurring events the proper time zone rather than flipping them to floating. 

I added some tests too, one for [RT #43610](https://rt.cpan.org/Ticket/Display.html?id=43610) and one for the TZ change I made to recurring events.
